### PR TITLE
fix/pedal_system_constants

### DIFF
--- a/include/VCF_Constants.h
+++ b/include/VCF_Constants.h
@@ -101,6 +101,12 @@ namespace VCFInterfaceConstants {
     constexpr float BRAKE_PRESSURE_REAR_SCALE = 1.0;
     constexpr float BRAKE_PRESSURE_REAR_OFFSET = 0;
 
+}
+
+// calibration and processing constants
+namespace VCFSystemConstants { 
+    constexpr float LBS_TO_NEWTONS = 4.4482216153;
+
     // EEPROM addresses for min and max calibration values
     constexpr uint32_t ACCEL_1_MIN_ADDR = 0;
     constexpr uint32_t ACCEL_2_MIN_ADDR = 4;
@@ -113,7 +119,7 @@ namespace VCFInterfaceConstants {
     constexpr uint32_t ACCEL_MAX_SENSOR_PEDAL_2 = 4000;
     constexpr float ACCEL_DEADZONE_MARGIN = 0.03f;
     constexpr float ACCEL_MECHANICAL_ACTIVATION_PERCENTAGE = 0.05f;
-
+    
     constexpr uint32_t BRAKE_1_MIN_ADDR = 16;
     constexpr uint32_t BRAKE_2_MIN_ADDR = 20;
     constexpr uint32_t BRAKE_1_MAX_ADDR = 24;
@@ -125,11 +131,6 @@ namespace VCFInterfaceConstants {
     constexpr uint32_t BRAKE_MAX_SENSOR_PEDAL_2 = 4000;
     constexpr float BRAKE_DEADZONE_MARGIN = 0.04f;
     constexpr float BRAKE_MECHANICAL_ACTIVATION_PERCENTAGE = 0.5f;
-}
-
-// calibration and processing constants
-namespace VCFSystemConstants { 
-    constexpr float LBS_TO_NEWTONS = 4.4482216153;
 }
 
 // software configuration constants

--- a/include/VCF_Constants.h
+++ b/include/VCF_Constants.h
@@ -144,18 +144,21 @@ namespace VCFTaskConstants {
     constexpr unsigned long CAN_SEND_PRIORITY = 10;
     constexpr unsigned long CAN_SEND_PERIOD = 2000;               // 2 000 us = 500 Hz
 
+    constexpr unsigned long PEDALS_PRIORITY = 5;
     constexpr unsigned long PEDALS_SEND_PERIOD = 4000;            // 4 000 us = 250 Hz
     constexpr unsigned long PEDALS_SAMPLE_PERIOD = 500;           // 500 us = 2 kHz
-    constexpr unsigned long PEDALS_PRIORITY = 5;
 
-    constexpr unsigned long BUZZER_WRITE_PERIOD = 100000;         // 100 000 us = 10 Hz
+    constexpr unsigned long PEDALS_RECALIBRATION_PRIORITY = 150;
+    constexpr unsigned long PEDALS_RECALIBRATION_PERIOD = 100000; // 100 000 us = 10 Hz
+
     constexpr unsigned long BUZZER_PRIORITY = 20;
+    constexpr unsigned long BUZZER_WRITE_PERIOD = 100000;         // 100 000 us = 10 Hz
 
-    constexpr unsigned long DASH_SAMPLE_PERIOD = 100000;          // 100 000 us = 10 Hz
     constexpr unsigned long DASH_SAMPLE_PRIORITY = 21;
+    constexpr unsigned long DASH_SAMPLE_PERIOD = 100000;          // 100 000 us = 10 Hz
 
-    constexpr unsigned long DASH_SEND_PERIOD = 100000;            // 100 000 us = 10 Hz
     constexpr unsigned long DASH_SEND_PRIORITY = 7;
+    constexpr unsigned long DASH_SEND_PERIOD = 100000;            // 100 000 us = 10 Hz
 
     constexpr unsigned long DEBUG_PRIORITY = 100;
     constexpr unsigned long DEBUG_PERIOD = 10000;                 // 10 000 us = 2 Hz
@@ -163,20 +166,17 @@ namespace VCFTaskConstants {
     constexpr unsigned long NEOPIXEL_UPDATE_PRIORITY = 90;
     constexpr unsigned long NEOPIXEL_UPDATE_PERIOD = 100000;      // 100 000 us = 10 Hz
 
-    constexpr unsigned long STEERING_SEND_PERIOD = 4000;          // 4 000 us = 250 Hz
     constexpr unsigned long STEERING_SEND_PRIORITY = 25;
+    constexpr unsigned long STEERING_SEND_PERIOD = 4000;          // 4 000 us = 250 Hz
 
-    constexpr unsigned long LOADCELL_SAMPLE_PERIOD = 250;         // 250 us = 4 kHz
     constexpr unsigned long LOADCELL_SAMPLE_PRIORITY = 24;
+    constexpr unsigned long LOADCELL_SAMPLE_PERIOD = 250;         // 250 us = 4 kHz
 
-    constexpr unsigned long ETHERNET_SEND_PERIOD = 100000;        // 100 000 us = 10Hz
     constexpr unsigned long ETHERNET_SEND_PRIORITY = 20;
+    constexpr unsigned long ETHERNET_SEND_PERIOD = 100000;        // 100 000 us = 10Hz
 
-    constexpr unsigned long LOADCELL_SEND_PERIOD = 4000;          // 4 000 us = 250 Hz
     constexpr unsigned long LOADCELL_SEND_PRIORITY = 25;
-
-    constexpr unsigned long PEDALS_RECALIBRATION_PRIORITY = 150;
-    constexpr unsigned long PEDALS_RECALIBRATION_PERIOD = 100000; // 100 000 us = 10 Hz
+    constexpr unsigned long LOADCELL_SEND_PERIOD = 4000;          // 4 000 us = 250 Hz
     
     // IIR filter alphas
     constexpr float LOADCELL_IIR_FILTER_ALPHA = 0.01f;

--- a/lib/interfaces/src/VCFEthernetInterface.cpp
+++ b/lib/interfaces/src/VCFEthernetInterface.cpp
@@ -16,6 +16,7 @@ hytech_msgs_VCFData_s VCFEthernetInterface::make_vcf_data_msg(ADCInterface &ADCI
     out.has_steering_data = true;
     out.has_vcf_ethernet_link_data = true;
     out.has_vcf_shutdown_data = true;
+    out.has_brake_pressure_data = true;
 
     // Load cells
     out.front_loadcell_data.FL_loadcell_analog = static_cast<uint32_t>(ADCInterfaceInstance.get_filtered_FL_load_cell());
@@ -58,6 +59,10 @@ hytech_msgs_VCFData_s VCFEthernetInterface::make_vcf_data_msg(ADCInterface &ADCI
     out.pedals_system_data.accel_percent = pedalsInstance.get_pedals_system_data().accel_percent;
     out.pedals_system_data.brake_percent = pedalsInstance.get_pedals_system_data().brake_percent;
     out.pedals_system_data.regen_percent = pedalsInstance.get_pedals_system_data().regen_percent;
+
+    // Brake pressure
+    out.brake_pressure_data.front_brake_pressure = ADCInterfaceInstance.get_brake_pressure_front().conversion;
+    out.brake_pressure_data.rear_brake_pressure = ADCInterfaceInstance.get_brake_pressure_rear().conversion;
 
     // Shutdown Senses
     out.vcf_shutdown_data.d_inertia_switch_out_read = ADCInterfaceInstance.shdn_d().conversion;

--- a/lib/systems/include/PedalsSystem.h
+++ b/lib/systems/include/PedalsSystem.h
@@ -65,8 +65,6 @@ public:
         _sensorData.accel_2 = pedal_data.accel_2;
         _sensorData.brake_1 = pedal_data.brake_1;
         _sensorData.brake_2 = pedal_data.brake_2;
-        _sensorData.brake_pressure_front = pedal_data.brake_pressure_front;
-        _sensorData.brake_pressure_rear = pedal_data.brake_pressure_rear;
     }
 
     const PedalsSystemData_s &get_pedals_system_data()

--- a/lib/systems/include/PedalsSystem.h
+++ b/lib/systems/include/PedalsSystem.h
@@ -65,7 +65,8 @@ public:
         _sensorData.accel_2 = pedal_data.accel_2;
         _sensorData.brake_1 = pedal_data.brake_1;
         _sensorData.brake_2 = pedal_data.brake_2;
-        _sensorData.pedal_pressure = pedal_data.pedal_pressure; //TODO: change this to use brake pressure front and rear
+        _sensorData.brake_pressure_front = pedal_data.brake_pressure_front;
+        _sensorData.brake_pressure_rear = pedal_data.brake_pressure_rear;
     }
 
     const PedalsSystemData_s &get_pedals_system_data()

--- a/lib/systems/src/PedalsSystem.cpp
+++ b/lib/systems/src/PedalsSystem.cpp
@@ -55,9 +55,10 @@ void PedalsSystem::evaluate_pedals(PedalSensorData_s pedals_data, unsigned long 
     
     bool accel_pressed = accel_percent > _accelParams.activation_percentage;
     bool brake_pressed = brake_percent > _brakeParams.activation_percentage;
+    bool mech_brake_pressed = brake_percent >= _brakeParams.mechanical_activation_percentage;
     _systemData.accel_is_pressed = accel_pressed;
     _systemData.brake_is_pressed = brake_pressed;
-    bool mech_brake_pressed = brake_percent >= _brakeParams.mechanical_activation_percentage;
+    _systemData.mech_brake_is_active = mech_brake_pressed;
 
     _systemData.brake_and_accel_pressed_implausibility_high = accel_pressed && _systemData.brake_is_pressed;
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@
 lib_deps_shared =
   nanopb/Nanopb@0.4.91
   https://github.com/hytech-racing/shared_firmware_systems.git
-  https://github.com/hytech-racing/shared_firmware_types.git#3820537c7ca582e152fb41f8041e625079a7e065
+  https://github.com/hytech-racing/shared_firmware_types.git
   https://github.com/hytech-racing/HT_SCHED#c13cff762c59dd82a8c273e3e98fd1a80622656d
   https://github.com/hytech-racing/HT_proto/releases/download/2026-04-02T21_09_09/hytech_msgs_pb_lib.tar.gz
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ lib_deps_shared =
   https://github.com/hytech-racing/shared_firmware_systems.git
   https://github.com/hytech-racing/shared_firmware_types.git#3820537c7ca582e152fb41f8041e625079a7e065
   https://github.com/hytech-racing/HT_SCHED#c13cff762c59dd82a8c273e3e98fd1a80622656d
-  https://github.com/hytech-racing/HT_proto/releases/download/2026-03-29T02_07_57/hytech_msgs_pb_lib.tar.gz
+  https://github.com/hytech-racing/HT_proto/releases/download/2026-04-02T21_09_09/hytech_msgs_pb_lib.tar.gz
 
   etlcpp/Embedded Template Library
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@
 lib_deps_shared =
   nanopb/Nanopb@0.4.91
   https://github.com/hytech-racing/shared_firmware_systems.git
-  https://github.com/hytech-racing/shared_firmware_types.git
+  https://github.com/hytech-racing/shared_firmware_types.git#3820537c7ca582e152fb41f8041e625079a7e065
   https://github.com/hytech-racing/HT_SCHED#c13cff762c59dd82a8c273e3e98fd1a80622656d
   https://github.com/hytech-racing/HT_proto/releases/download/2026-03-29T02_07_57/hytech_msgs_pb_lib.tar.gz
 

--- a/src/VCF_Tasks.cpp
+++ b/src/VCF_Tasks.cpp
@@ -32,9 +32,7 @@ HT_TASK::TaskResponse run_read_adc0_task(const unsigned long& sysMicros, const H
         .accel_1 = static_cast<uint32_t>(ADCInterfaceInstance::instance().acceleration_1().conversion),
         .accel_2 = static_cast<uint32_t>(ADCInterfaceInstance::instance().acceleration_2().conversion),
         .brake_1 = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_1().conversion),
-        .brake_2 = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_2().conversion),
-        .brake_pressure_front = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_pressure_front().conversion),
-        .brake_pressure_rear = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_pressure_rear().conversion)
+        .brake_2 = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_2().conversion)
     });
     return HT_TASK::TaskResponse::YIELD;
 }

--- a/src/VCF_Tasks.cpp
+++ b/src/VCF_Tasks.cpp
@@ -69,14 +69,14 @@ HT_TASK::TaskResponse update_pedals_calibration_task(const unsigned long& sysMic
     {
         // PedalsSystemInstance::instance().recalibrate_min_max(VCFData_sInstance::instance().interface_data.pedal_sensor_data);
         PedalsSystemInstance::instance().recalibrate_min_max(PedalsSystemInstance::instance().get_pedals_sensor_data());
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::ACCEL_1_MIN_ADDR, PedalsSystemInstance::instance().get_accel_params().min_pedal_1);
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::ACCEL_1_MAX_ADDR, PedalsSystemInstance::instance().get_accel_params().max_pedal_1);
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::ACCEL_2_MIN_ADDR, PedalsSystemInstance::instance().get_accel_params().min_pedal_2);
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::ACCEL_2_MAX_ADDR, PedalsSystemInstance::instance().get_accel_params().max_pedal_2);
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::BRAKE_1_MIN_ADDR, PedalsSystemInstance::instance().get_brake_params().min_pedal_1);
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::BRAKE_1_MAX_ADDR, PedalsSystemInstance::instance().get_brake_params().max_pedal_1);
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::BRAKE_2_MIN_ADDR, PedalsSystemInstance::instance().get_brake_params().min_pedal_2);
-        EEPROMUtilities::write_eeprom_32bit(VCFInterfaceConstants::BRAKE_2_MAX_ADDR, PedalsSystemInstance::instance().get_brake_params().max_pedal_2);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::ACCEL_1_MIN_ADDR, PedalsSystemInstance::instance().get_accel_params().min_pedal_1);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::ACCEL_1_MAX_ADDR, PedalsSystemInstance::instance().get_accel_params().max_pedal_1);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::ACCEL_2_MIN_ADDR, PedalsSystemInstance::instance().get_accel_params().min_pedal_2);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::ACCEL_2_MAX_ADDR, PedalsSystemInstance::instance().get_accel_params().max_pedal_2);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::BRAKE_1_MIN_ADDR, PedalsSystemInstance::instance().get_brake_params().min_pedal_1);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::BRAKE_1_MAX_ADDR, PedalsSystemInstance::instance().get_brake_params().max_pedal_1);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::BRAKE_2_MIN_ADDR, PedalsSystemInstance::instance().get_brake_params().min_pedal_2);
+        EEPROMUtilities::write_eeprom_32bit(VCFSystemConstants::BRAKE_2_MAX_ADDR, PedalsSystemInstance::instance().get_brake_params().max_pedal_2);
     }
 
     return HT_TASK::TaskResponse::YIELD;
@@ -535,33 +535,33 @@ void setup_all_interfaces() {
 
     // Create pedals singleton
     PedalsParams accel_params = {
-        .min_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::ACCEL_1_MIN_ADDR),
-        .min_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::ACCEL_2_MIN_ADDR),
-        .max_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::ACCEL_1_MAX_ADDR),
-        .max_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::ACCEL_2_MAX_ADDR),
-        .activation_percentage = VCFInterfaceConstants::ACCEL_ACTIVATION_PERCENTAGE,
-        .min_sensor_pedal_1 = VCFInterfaceConstants::ACCEL_MIN_SENSOR_PEDAL_1,
-        .min_sensor_pedal_2 = VCFInterfaceConstants::ACCEL_MIN_SENSOR_PEDAL_2,
-        .max_sensor_pedal_1 = VCFInterfaceConstants::ACCEL_MAX_SENSOR_PEDAL_1,
-        .max_sensor_pedal_2 = VCFInterfaceConstants::ACCEL_MAX_SENSOR_PEDAL_2,
-        .deadzone_margin = VCFInterfaceConstants::ACCEL_DEADZONE_MARGIN,
+        .min_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::ACCEL_1_MIN_ADDR),
+        .min_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::ACCEL_2_MIN_ADDR),
+        .max_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::ACCEL_1_MAX_ADDR),
+        .max_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::ACCEL_2_MAX_ADDR),
+        .activation_percentage = VCFSystemConstants::ACCEL_ACTIVATION_PERCENTAGE,
+        .min_sensor_pedal_1 = VCFSystemConstants::ACCEL_MIN_SENSOR_PEDAL_1,
+        .min_sensor_pedal_2 = VCFSystemConstants::ACCEL_MIN_SENSOR_PEDAL_2,
+        .max_sensor_pedal_1 = VCFSystemConstants::ACCEL_MAX_SENSOR_PEDAL_1,
+        .max_sensor_pedal_2 = VCFSystemConstants::ACCEL_MAX_SENSOR_PEDAL_2,
+        .deadzone_margin = VCFSystemConstants::ACCEL_DEADZONE_MARGIN,
         .implausibility_margin = IMPLAUSIBILITY_PERCENT,
-        .mechanical_activation_percentage = VCFInterfaceConstants::ACCEL_MECHANICAL_ACTIVATION_PERCENTAGE
+        .mechanical_activation_percentage = VCFSystemConstants::ACCEL_MECHANICAL_ACTIVATION_PERCENTAGE
     };
     
     PedalsParams brake_params = {
-        .min_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::BRAKE_1_MIN_ADDR),
-        .min_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::BRAKE_2_MIN_ADDR),
-        .max_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::BRAKE_1_MAX_ADDR),
-        .max_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFInterfaceConstants::BRAKE_2_MAX_ADDR),
-        .activation_percentage = VCFInterfaceConstants::BRAKE_ACTIVATION_PERCENTAGE,
-        .min_sensor_pedal_1 = VCFInterfaceConstants::BRAKE_MIN_SENSOR_PEDAL_1,
-        .min_sensor_pedal_2 = VCFInterfaceConstants::BRAKE_MIN_SENSOR_PEDAL_2,
-        .max_sensor_pedal_1 = VCFInterfaceConstants::BRAKE_MAX_SENSOR_PEDAL_1,
-        .max_sensor_pedal_2 = VCFInterfaceConstants::BRAKE_MAX_SENSOR_PEDAL_2,
-        .deadzone_margin = VCFInterfaceConstants::BRAKE_DEADZONE_MARGIN,
+        .min_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::BRAKE_1_MIN_ADDR),
+        .min_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::BRAKE_2_MIN_ADDR),
+        .max_pedal_1 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::BRAKE_1_MAX_ADDR),
+        .max_pedal_2 = EEPROMUtilities::read_eeprom_32bit(VCFSystemConstants::BRAKE_2_MAX_ADDR),
+        .activation_percentage = VCFSystemConstants::BRAKE_ACTIVATION_PERCENTAGE,
+        .min_sensor_pedal_1 = VCFSystemConstants::BRAKE_MIN_SENSOR_PEDAL_1,
+        .min_sensor_pedal_2 = VCFSystemConstants::BRAKE_MIN_SENSOR_PEDAL_2,
+        .max_sensor_pedal_1 = VCFSystemConstants::BRAKE_MAX_SENSOR_PEDAL_1,
+        .max_sensor_pedal_2 = VCFSystemConstants::BRAKE_MAX_SENSOR_PEDAL_2,
+        .deadzone_margin = VCFSystemConstants::BRAKE_DEADZONE_MARGIN,
         .implausibility_margin = IMPLAUSIBILITY_PERCENT,
-        .mechanical_activation_percentage = VCFInterfaceConstants::BRAKE_MECHANICAL_ACTIVATION_PERCENTAGE
+        .mechanical_activation_percentage = VCFSystemConstants::BRAKE_MECHANICAL_ACTIVATION_PERCENTAGE
     };
 
     PedalsSystemInstance::create(accel_params, brake_params); //pass in the two different params

--- a/src/VCF_Tasks.cpp
+++ b/src/VCF_Tasks.cpp
@@ -32,7 +32,8 @@ HT_TASK::TaskResponse run_read_adc0_task(const unsigned long& sysMicros, const H
         .accel_2 = static_cast<uint32_t>(ADCInterfaceInstance::instance().acceleration_2().conversion),
         .brake_1 = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_1().conversion),
         .brake_2 = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_2().conversion),
-        .pedal_pressure = 0 // TODO: Need changes to support both brake pressure sensors
+        .brake_pressure_front = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_pressure_front().conversion),
+        .brake_pressure_rear = static_cast<uint32_t>(ADCInterfaceInstance::instance().brake_pressure_rear().conversion)
     });
     return HT_TASK::TaskResponse::YIELD;
 }
@@ -239,12 +240,13 @@ HT_TASK::TaskResponse enqueue_pedals_data(const unsigned long &sys_micros, const
     pedals_data.brake_pedal_active = PedalsSystemInstance::instance().get_pedals_system_data().brake_is_pressed;
     pedals_data.mechanical_brake_active = PedalsSystemInstance::instance().get_pedals_system_data().mech_brake_is_active;
     pedals_data.implaus_exceeded_max_duration = PedalsSystemInstance::instance().get_pedals_system_data().implausibility_has_exceeded_max_duration;
-
     
     pedals_data.accel_pedal_ro = HYTECH_accel_pedal_ro_toS(PedalsSystemInstance::instance().get_pedals_system_data().accel_percent);
     pedals_data.brake_pedal_ro = HYTECH_brake_pedal_ro_toS(PedalsSystemInstance::instance().get_pedals_system_data().brake_percent);
     // Serial.println(pedals_data.brake_pedal_ro);
     // Serial.println(pedals_data.accel_pedal_ro);
+
+    // TODO: Need to add brake pressure data to CAN msg
     CAN_util::enqueue_msg(&pedals_data, &Pack_PEDALS_SYSTEM_DATA_hytech, VCFCANInterfaceImpl::VCFCANInterfaceObjectsInstance::instance().main_can_tx_buffer);
     return HT_TASK::TaskResponse::YIELD;
 }


### PR DESCRIPTION
moved the constants from VCFInterfaceConstants namespace to VCFSystemConstants namespace.
should quickly validate with pedal box once its made.