### PR TITLE
fix/suspot_calibration

### DIFF
--- a/include/VCF_Constants.h
+++ b/include/VCF_Constants.h
@@ -90,11 +90,11 @@ namespace VCFInterfaceConstants {
     constexpr float FL_LOADCELL_OFFSET = 0.0;
     constexpr float FR_LOADCELL_SCALE =  1.0; //Values 
     constexpr float FR_LOADCELL_OFFSET = 0.0;
-
-    constexpr float FR_SUS_POT_SCALE = 1.0;
-    constexpr float FR_SUS_POT_OFFSET = 0;
-    constexpr float FL_SUS_POT_SCALE = 1.0;
-    constexpr float FL_SUS_POT_OFFSET = 0;
+    
+    constexpr float FR_SUS_POT_SCALE = 0.01396; // Calibrated for mm between mounting bolts
+    constexpr float FR_SUS_POT_OFFSET = 150.8; // Can change offset once car is on ground to center at zero
+    constexpr float FL_SUS_POT_SCALE = 0.01396; // Same as FR
+    constexpr float FL_SUS_POT_OFFSET = 150.8;
 
     constexpr float BRAKE_PRESSURE_FRONT_SCALE = 1.0;
     constexpr float BRAKE_PRESSURE_FRONT_OFFSET = 0;

--- a/lib/interfaces/src/ADCInterface.cpp
+++ b/lib/interfaces/src/ADCInterface.cpp
@@ -79,12 +79,12 @@ void ADCInterface::update_filtered_values(float alpha) {
     _FL_sus_pot_filtered = iir_filter(
         alpha,
         _FL_sus_pot_filtered,
-        static_cast<float>(FL_sus_pot().raw)
+        FL_sus_pot().conversion
     );
     _FR_sus_pot_filtered = iir_filter(
         alpha,
         _FR_sus_pot_filtered,
-        static_cast<float>(FR_sus_pot().raw)
+        FR_sus_pot().conversion
     );
 }
 


### PR DESCRIPTION
calibrated sus pots so that ADC conversion will reflect the distance in mm between the mounting bolts.